### PR TITLE
explict workdir in manifests

### DIFF
--- a/api/okteto.yml
+++ b/api/okteto.yml
@@ -3,6 +3,7 @@ command: ["bash"]
 forward:
   - 8080:8080
   - 9229:9229
+workdir: /src
 sync:
   - .:/src
 persistentVolume:

--- a/frontend/okteto.yml
+++ b/frontend/okteto.yml
@@ -1,6 +1,7 @@
 name: frontend
 image: okteto/movies-frontend:dev
 command: yarn start
+workdir: /src
 sync:
   - .:/src
 persistentVolume:


### PR DESCRIPTION
without this, the vscode plugin opens the `/usr/src/app` since there's no clue on what folder to open.