### PR TITLE
remove air and dlv since they are no longer needed on the main build

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,11 +1,5 @@
 FROM golang:buster as dev
 
-# setup okteto message
-COPY bashrc /root/.bashrc
-
-RUN go install github.com/go-delve/delve/cmd/dlv@latest && \
-    curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin
-
 WORKDIR /usr/src/app
 
 ADD go.mod go.sum ./

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,11 +1,5 @@
 FROM golang:buster as dev
 
-# setup okteto message
-COPY bashrc /root/.bashrc
-
-RUN go install github.com/go-delve/delve/cmd/dlv@latest && \
-    curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b /usr/bin
-
 WORKDIR /usr/src/app
 
 ADD go.mod go.sum ./


### PR DESCRIPTION
Remove air and dlv since they are no longer needed on the main build. the demo now uses okteto/golang:1.22 directly. Also, air is not compatible with 1.22, so it's breaking the build