### PR TITLE
Update deploy preview configuration and remove GITHUB_TOKEN

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -14,7 +14,7 @@ jobs:
         url: ${{ secrets.OKTETO_URL }}
 
     - name: Deploy preview environment
-      uses: okteto/deploy-preview@latest
+      uses: okteto/deploy-preview@ifbyol/fix-return-when-no-preview
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -14,7 +14,7 @@ jobs:
         url: ${{ secrets.OKTETO_URL }}
 
     - name: Deploy preview environment
-      uses: okteto/deploy-preview@ifbyol/fix-return-when-no-preview
+      uses: okteto/deploy-preview@a
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -15,8 +15,6 @@ jobs:
 
     - name: Deploy preview environment
       uses: okteto/deploy-preview@a
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         name: pr-${{ github.event.number }}-cindylopez
         scope: global

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -14,7 +14,7 @@ jobs:
         url: ${{ secrets.OKTETO_URL }}
 
     - name: Deploy preview environment
-      uses: okteto/deploy-preview@a
+      uses: okteto/deploy-preview@rb/update-go-version
       with:
-        name: pr-${{ github.event.number }}-cindylopez
+        name: pr-${{ github.event.number }}-jlopezbarb
         scope: global


### PR DESCRIPTION
Revise the deploy preview action and update the preview name format while eliminating the GITHUB_TOKEN environment variable from the deployment step.