### PR TITLE
Switch PostgreSQL and Kafka images to Bitnami Legacy registry

### DIFF
--- a/kafka/values.yml
+++ b/kafka/values.yml
@@ -1,3 +1,6 @@
+image:
+  repository: bitnamilegacy/kafka
+
 controller:
   replicaCount: 1
 
@@ -11,4 +14,3 @@ persistence:
 zookeeper:
   persistence:
     size: 1Gi
-

--- a/postgresql/values.yml
+++ b/postgresql/values.yml
@@ -1,3 +1,6 @@
+image:
+  repository: bitnamilegacy/postgresql
+
 auth:
   username: okteto
   password: okteto


### PR DESCRIPTION
This PR updates our Helm values to use images from the bitnamilegacy registry instead of bitnami. Bitnami has announced the deprecation of their public container images, and the bitnamilegacy/* provides frozen copies of the existing tags to ensure stability.

Changes included:

- Updated main application images for PostgreSQL and Kafka to docker.io/bitnamilegacy/*.
- No functional changes expected; this is a precautionary update to avoid pull errors once the original repositories are retired.

⚠️ Note: bitnamilegacy images are no longer maintained with security patches. This update is intended as a temporary safeguard while we evaluate long-term alternatives.