### PR TITLE
Fix PostgreSQL health checks to use correct database

### DIFF
--- a/infrastructure/chart/templates/postgresql-deployment.yaml
+++ b/infrastructure/chart/templates/postgresql-deployment.yaml
@@ -50,7 +50,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - pg_isready -U {{ .Values.postgresql.auth.username }} -h localhost
+                - pg_isready -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -h localhost
             initialDelaySeconds: 30
             periodSeconds: 10
           readinessProbe:
@@ -58,7 +58,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - pg_isready -U {{ .Values.postgresql.auth.username }} -h localhost
+                - pg_isready -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -h localhost
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:


### PR DESCRIPTION
## Summary
- Fixed `pg_isready` liveness and readiness probes missing the `-d` database flag
- Without this flag, health checks defaulted to connecting to database "okteto" (matching the username) instead of "rentals" (the actual database)
- This caused repeated "database 'okteto' does not exist" errors in PostgreSQL logs

## Test plan
- [x] Verified Helm chart renders correctly with `helm template`
- [x] Deployed fix with `okteto deploy`
- [x] Confirmed PostgreSQL pod is healthy (1/1 Running)
- [x] Verified logs no longer contain "database 'okteto' does not exist" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)