### PR TITLE
Add CLAUDE.md and dev-setup slash command for AI agent support

### DIFF
--- a/.claude/commands/dev-setup.md
+++ b/.claude/commands/dev-setup.md
@@ -1,0 +1,28 @@
+Set up the Okteto development environment for this project. Follow these steps:
+
+1. **Check prerequisites**:
+   - Run `okteto version` to confirm the CLI is installed
+   - Run `okteto context show` to confirm the user is connected to an Okteto instance
+   - If either fails, stop and help the user install/configure Okteto
+
+2. **Deploy all services**:
+   - Run `okteto deploy --wait`
+   - This builds images and deploys all microservices (frontend, catalog, rent, worker, api) plus infrastructure (PostgreSQL, Kafka, MongoDB)
+   - Wait for it to complete successfully
+
+3. **Show the running environment**:
+   - Run `okteto endpoints` to display the public URLs
+   - Share the URLs with the user so they can open the app in their browser
+
+4. **Guide the user to start development**:
+   - Ask which service they want to work on (frontend, catalog, rent, worker, or api)
+   - Tell them to run `okteto up <service>` **in their terminal** (this is interactive — do not run it yourself)
+   - Once they confirm it's running, remind them of the dev commands for that service:
+     - **frontend**: `yarn install && yarn start`
+     - **catalog**: starts automatically
+     - **rent**: starts automatically
+     - **api**: `make build && make start`
+     - **worker**: `make build && make start`
+
+5. **Confirm readiness**:
+   - Let the user know you can now help with: running tests (`okteto exec -- <cmd>`), debugging errors, reading code, and analyzing logs (`okteto logs <service>`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@ Once the user has `okteto up <service>` running in their terminal:
 - **Read synced files**: Use the Read tool to examine code that's syncing to the cluster
 - **Analyze pasted output**: When the user hits an error, they can paste terminal output for analysis
 - **Check logs**: `okteto logs <service>` shows container logs (separate from the interactive session)
+- **Run e2e tests**: Use `okteto test` to run the Playwright test suite against the live environment in the cluster
 
 You're facilitating their development workflow, not trying to observe their terminal session.
 
@@ -64,6 +65,7 @@ Agent actions:
   4. Identifies the bug and suggests a fix
 
 Developer applies the fix (auto-syncs to container), agent re-runs tests to confirm.
+Agent runs: okteto test                  → runs e2e tests to verify nothing else broke.
 ```
 
 ### Debugging Patterns
@@ -72,6 +74,7 @@ Developer applies the fix (auto-syncs to container), agent re-runs tests to conf
 - **User pastes an error**: Read relevant code files, analyze, suggest fix
 - **User asks "why is this failing?"**: Run diagnostic commands via `okteto exec`
 - **User makes code changes**: Changes auto-sync; help them understand what to run next
+- **User asks to run e2e tests**: `okteto test` runs the Playwright suite in the cluster
 
 ## Service-Specific Dev Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,114 @@
+# Movies App - AI Agent Guide
+
+## Project Overview
+Microservices-based Movies rental application demonstrating Okteto development on Kubernetes. Deployed via Helm charts. The agent can deploy all services with a single `okteto deploy`, then help the user debug any individual service.
+
+## Architecture
+
+### Services
+- **frontend**: React app with webpack hot-reload
+- **catalog**: Node.js service serving movies from MongoDB
+- **rent**: Java service handling rent requests → Kafka
+- **worker**: Go service processing Kafka messages → PostgreSQL
+- **api**: Go service retrieving rentals from PostgreSQL
+
+### Data Stores
+- MongoDB: Movie catalog
+- Kafka: Message queue for rent requests
+- PostgreSQL: Rental records
+
+## Key Files
+- `okteto.yaml`: Okteto manifest (source of truth for build/deploy/dev)
+- Each service has its own directory with independent build setup
+- Helm charts in each service's `chart/` directory
+
+## For AI Agents
+
+### Setting Up the Environment
+
+When a user asks to set up or deploy their development environment:
+
+1. **Check prerequisites**: Run `okteto version` and `okteto context show`
+2. **Deploy**: Run `okteto deploy --wait` to build images and deploy all services
+3. **Show endpoints**: Run `okteto endpoints` so the user can access the app
+4. **Guide the user** to start development on a specific service with `okteto up <service>`
+
+### The `okteto up` Rule
+
+**`okteto up` is interactive and must be run by the user in their terminal.** It opens a shell inside the development container with live file sync. Never run it as a background task. Instead, tell the user which command to run:
+
+```
+Run this in your terminal: okteto up worker
+```
+
+### Collaborative Workflow
+
+Once the user has `okteto up <service>` running in their terminal:
+
+- **Run diagnostics**: Use `okteto exec -- <command>` to execute commands in the dev container and see output
+- **Read synced files**: Use the Read tool to examine code that's syncing to the cluster
+- **Analyze pasted output**: When the user hits an error, they can paste terminal output for analysis
+- **Check logs**: `okteto logs <service>` shows container logs (separate from the interactive session)
+
+You're facilitating their development workflow, not trying to observe their terminal session.
+
+### Example Interaction
+
+```
+Developer: "I'm working on the worker service, my tests are failing"
+
+Agent actions:
+  1. okteto exec -- make build        → builds the Go binary in the container
+  2. okteto exec -- go test ./...     → runs tests, captures output
+  3. Reads the failing test file and source code
+  4. Identifies the bug and suggests a fix
+
+Developer applies the fix (auto-syncs to container), agent re-runs tests to confirm.
+```
+
+### Debugging Patterns
+
+- **User asks to run tests**: `okteto exec -- make test` or `okteto exec -- go test ./...`
+- **User pastes an error**: Read relevant code files, analyze, suggest fix
+- **User asks "why is this failing?"**: Run diagnostic commands via `okteto exec`
+- **User makes code changes**: Changes auto-sync; help them understand what to run next
+
+## Service-Specific Dev Commands
+
+Once inside a development container (`okteto up <service>`):
+
+| Service | Language | Build & Run |
+|---------|----------|-------------|
+| **frontend** | Node.js | `yarn install && yarn start` |
+| **catalog** | Node.js | `yarn start` (auto-starts via dev command) |
+| **rent** | Java | `mvn spring-boot:run` (auto-starts via dev command) |
+| **api** | Go | `make build && make start` |
+| **worker** | Go | `make build && make start` |
+
+## Okteto CLI Quick Reference
+
+| Command | Who runs it | Purpose |
+|---------|-------------|---------|
+| `okteto deploy --wait` | Agent | Build images and deploy all services |
+| `okteto build` | Agent | Build and push images only |
+| `okteto up <service>` | **User** | Start interactive dev container (never run as agent) |
+| `okteto down` | Agent/User | Stop dev mode, restore deployment |
+| `okteto exec -- <cmd>` | Agent | Run a command in the dev container |
+| `okteto logs <service>` | Agent | View container logs |
+| `okteto endpoints` | Agent | List public URLs |
+| `okteto test` | Agent | Run e2e tests in the cluster |
+| `okteto destroy` | User | Tear down all resources |
+
+## Common Mistakes
+
+- **Forgetting to deploy first**: Run `okteto deploy` before `okteto up` if services aren't already deployed
+- **Not specifying the service**: With multiple services, always specify which one: `okteto up worker`
+- **Using kubectl/helm directly**: Always use `okteto deploy` so Okteto can track resources
+- **Building Docker images locally**: Use `okteto build` to leverage the Okteto Build Service
+
+## Troubleshooting
+
+- `okteto doctor`: Generate a diagnostic bundle
+- `okteto status`: Check file sync progress
+- `okteto logs --since 5m`: Recent service logs
+- `okteto context show`: Verify cluster and namespace

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Once the user has `okteto up <service>` running in their terminal:
 - **Read synced files**: Use the Read tool to examine code that's syncing to the cluster
 - **Analyze pasted output**: When the user hits an error, they can paste terminal output for analysis
 - **Check logs**: `okteto logs <service>` shows container logs (separate from the interactive session)
-- **Run e2e tests**: Use `okteto test` to run the Playwright test suite against the live environment in the cluster
+- **Run e2e tests**: Use `okteto test e2e` to run the Playwright test suite against the live environment in the cluster
 
 You're facilitating their development workflow, not trying to observe their terminal session.
 
@@ -65,7 +65,7 @@ Agent actions:
   4. Identifies the bug and suggests a fix
 
 Developer applies the fix (auto-syncs to container), agent re-runs tests to confirm.
-Agent runs: okteto test                  → runs e2e tests to verify nothing else broke.
+Agent runs: okteto test e2e              → runs e2e tests to verify nothing else broke.
 ```
 
 ### Debugging Patterns
@@ -74,7 +74,7 @@ Agent runs: okteto test                  → runs e2e tests to verify nothing el
 - **User pastes an error**: Read relevant code files, analyze, suggest fix
 - **User asks "why is this failing?"**: Run diagnostic commands via `okteto exec`
 - **User makes code changes**: Changes auto-sync; help them understand what to run next
-- **User asks to run e2e tests**: `okteto test` runs the Playwright suite in the cluster
+- **User asks to run e2e tests**: `okteto test e2e` runs the Playwright suite in the cluster
 
 ## Service-Specific Dev Commands
 
@@ -99,7 +99,7 @@ Once inside a development container (`okteto up <service>`):
 | `okteto exec -- <cmd>` | Agent | Run a command in the dev container |
 | `okteto logs <service>` | Agent | View container logs |
 | `okteto endpoints` | Agent | List public URLs |
-| `okteto test` | Agent | Run e2e tests in the cluster |
+| `okteto test e2e` | Agent | Run e2e tests in the cluster |
 | `okteto destroy` | User | Tear down all resources |
 
 ## Common Mistakes


### PR DESCRIPTION
Teach AI coding agents how to work with Okteto development environments. CLAUDE.md provides architecture context, CLI guardrails (e.g. never run okteto up in background), and collaborative debugging patterns. The dev-setup slash command gives developers a one-command workflow to deploy and start developing.