### PR TITLE
Add /health endpoint to API service with Kubernetes metadata

### DIFF
--- a/api/chart/templates/api-deployment.yaml
+++ b/api/chart/templates/api-deployment.yaml
@@ -33,3 +33,25 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CPU_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: api
+                  resource: limits.cpu
+            - name: MEMORY_LIMIT
+              valueFrom:
+                resourceFieldRef:
+                  containerName: api
+                  resource: limits.memory
+          resources:
+            limits:
+              cpu: "500m"
+              memory: "256Mi"
+            requests:
+              cpu: "100m"
+              memory: "128Mi"

--- a/api/chart/templates/api-ingress.yaml
+++ b/api/chart/templates/api-ingress.yaml
@@ -10,6 +10,13 @@ spec:
   rules:
     - http:
         paths:
+          - path: /health
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 8080
           - path: /rentals
             pathType: Prefix
             backend:

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"runtime"
 	"strconv"
 	"log"
 
@@ -60,6 +61,14 @@ type User struct {
 	Gender string
 }
 
+type Health struct {
+	Namespace        string `json:"namespace"`
+	Hostname         string `json:"hostname"`
+	NumCPU           int    `json:"cpu"`
+	CPULimitCores    string `json:"cpu_limit_cores,omitempty"`
+	MemoryLimitBytes string `json:"memory_limit_bytes,omitempty"`
+}
+
 func loadData() {
 	dropTableStmt := `DROP TABLE IF EXISTS users`
 	if _, err := db.Exec(dropTableStmt); err != nil {
@@ -97,11 +106,38 @@ func loadData() {
 func handleRequests() {
 	muxRouter := mux.NewRouter().StrictSlash(true)
 
+	muxRouter.HandleFunc("/health", health)
 	muxRouter.HandleFunc("/rentals", rentals)
 	muxRouter.HandleFunc("/users", allUsers)
 	muxRouter.HandleFunc("/users/{userid}", singleUser)
 
 	log.Fatal(http.ListenAndServe(":8080", muxRouter))
+}
+
+func health(w http.ResponseWriter, r *http.Request) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+
+	namespace := os.Getenv("POD_NAMESPACE")
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	cpuLimit := os.Getenv("CPU_LIMIT")
+	memoryLimit := os.Getenv("MEMORY_LIMIT")
+
+	healthStatus := Health{
+		Namespace:        namespace,
+		Hostname:         hostname,
+		NumCPU:           runtime.NumCPU(),
+		CPULimitCores:    cpuLimit,
+		MemoryLimitBytes: memoryLimit,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(healthStatus)
 }
 
 func rentals(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Added `/health` endpoint to the API service that exposes Kubernetes metadata
- Returns namespace, hostname (pod name), CPU count, and resource limits
- Updated Helm deployment to inject environment variables for namespace and resource limits
- Added resource requests and limits to the API deployment
- Updated ingress configuration to expose the `/health` endpoint

## Changes
- **api/cmd/api/main.go**: 
  - Added `Health` struct with fields for namespace, hostname, CPU, and resource limits
  - Implemented `health` handler function that returns Kubernetes metadata
  - Registered `/health` endpoint in the router
- **api/chart/templates/api-deployment.yaml**:
  - Added environment variables for `POD_NAMESPACE`, `CPU_LIMIT`, and `MEMORY_LIMIT`
  - Added resource requests (100m CPU, 128Mi memory) and limits (500m CPU, 256Mi memory)
- **api/chart/templates/api-ingress.yaml**:
  - Added `/health` path to the ingress rules

## Test Results
All e2e tests passed successfully:
- ✓ environment variables are set
- ✓ movies has title  
- ✓ catalog has entries

## Example Response
\`\`\`json
{
  "namespace": "rberrelleza",
  "hostname": "api-9667d589b-hptt8",
  "cpu": 4,
  "cpu_limit_cores": "1",
  "memory_limit_bytes": "268435456"
}
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)