### PR TITLE
Add real-time rental notifications via WebSockets

### DIFF
--- a/api/chart/templates/api-ingress.yaml
+++ b/api/chart/templates/api-ingress.yaml
@@ -6,6 +6,8 @@ metadata:
     {{- include "movies.labels" . | nindent 4 }}
   annotations:
     dev.okteto.com/generate-host: "movies"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
 spec:
   rules:
     - http:
@@ -18,6 +20,13 @@ spec:
                 port:
                   number: 8080
           - path: /users
+            pathType: Prefix
+            backend:
+              service:
+                name: api
+                port:
+                  number: 8080
+          - path: /api/ws
             pathType: Prefix
             backend:
               service:

--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -3,21 +3,110 @@ package main
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
-	"log"
+	"sync"
+	"time"
 
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
 	"github.com/okteto/movies/pkg/database"
 
-	"fmt"
-
 	_ "github.com/lib/pq"
-	"github.com/gorilla/mux"
 )
 
 var db *sql.DB
+
+type hub struct {
+	clients   map[*websocket.Conn]bool
+	broadcast chan []byte
+	mu        sync.Mutex
+}
+
+var wsHub = &hub{
+	clients:   make(map[*websocket.Conn]bool),
+	broadcast: make(chan []byte, 256),
+}
+
+func (h *hub) run() {
+	for msg := range h.broadcast {
+		h.mu.Lock()
+		log.Printf("Broadcasting to %d WebSocket clients: %s", len(h.clients), string(msg))
+		for client := range h.clients {
+			if err := client.WriteMessage(websocket.TextMessage, msg); err != nil {
+				log.Println("WebSocket write error:", err)
+				client.Close()
+				delete(h.clients, client)
+			}
+		}
+		h.mu.Unlock()
+	}
+}
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+func wsHandler(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println("WebSocket upgrade error:", err)
+		return
+	}
+	conn.SetReadDeadline(time.Now().Add(70 * time.Second))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(70 * time.Second))
+		return nil
+	})
+	wsHub.mu.Lock()
+	wsHub.clients[conn] = true
+	wsHub.mu.Unlock()
+	log.Printf("WebSocket client connected, total: %d", len(wsHub.clients))
+
+	// Send periodic pings to keep connection alive through nginx
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		for range ticker.C {
+			wsHub.mu.Lock()
+			_, ok := wsHub.clients[conn]
+			wsHub.mu.Unlock()
+			if !ok {
+				return
+			}
+			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				return
+			}
+		}
+	}()
+
+	for {
+		if _, _, err := conn.ReadMessage(); err != nil {
+			wsHub.mu.Lock()
+			delete(wsHub.clients, conn)
+			wsHub.mu.Unlock()
+			conn.Close()
+			log.Printf("WebSocket client disconnected, total: %d", len(wsHub.clients))
+			break
+		}
+	}
+}
+
+func notifyHandler(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		w.WriteHeader(400)
+		return
+	}
+	log.Printf("Notify received: %s (clients: %d)", string(body), len(wsHub.clients))
+	wsHub.broadcast <- body
+	w.WriteHeader(204)
+}
 
 func main() {
 	db = database.Open()
@@ -29,6 +118,8 @@ func main() {
 		loadData()
 		return
 	}
+
+	go wsHub.run()
 
 	fmt.Println("Running server on port 8080...")
 	handleRequests()
@@ -49,15 +140,15 @@ type Movie struct {
 }
 
 type User struct {
-	Userid int
+	Userid    int
 	Firstname string
-	Lastname string
-	Phone string
-	City string
-	State string
-	Zip string
-	Age int
-	Gender string
+	Lastname  string
+	Phone     string
+	City      string
+	State     string
+	Zip       string
+	Age       int
+	Gender    string
 }
 
 func loadData() {
@@ -100,6 +191,8 @@ func handleRequests() {
 	muxRouter.HandleFunc("/rentals", rentals)
 	muxRouter.HandleFunc("/users", allUsers)
 	muxRouter.HandleFunc("/users/{userid}", singleUser)
+	muxRouter.HandleFunc("/api/ws", wsHandler)
+	muxRouter.HandleFunc("/internal/notify", notifyHandler)
 
 	log.Fatal(http.ListenAndServe(":8080", muxRouter))
 }

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,4 +4,7 @@ go 1.24
 
 require github.com/lib/pq v1.10.5
 
-require github.com/gorilla/mux v1.8.0 // indirect
+require (
+	github.com/gorilla/mux v1.8.0 // indirect
+	github.com/gorilla/websocket v1.5.3 // indirect
+)

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,4 +1,6 @@
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/lib/pq v1.10.5 h1:J+gdV2cUmX7ZqL2B0lFcW0m+egaHC2V3lpO8nWxyYiQ=
 github.com/lib/pq v1.10.5/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json yarn.lock ./
 RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install
 COPY . .
 
-RUN --mount=type=cache,target=./node_modules/.cache/webpack yarn build
+RUN yarn build
 
 FROM nginx:alpine
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /usr/src/app
 
 COPY package.json yarn.lock ./
 RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install
+ARG CACHEBUST=1
 COPY . .
 
 RUN rm -rf node_modules/.cache/webpack && yarn build

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@ COPY package.json yarn.lock ./
 RUN --mount=type=cache,target=/root/.yarn YARN_CACHE_FOLDER=/root/.yarn yarn install
 COPY . .
 
-RUN yarn build
+RUN rm -rf node_modules/.cache/webpack && yarn build
 
 FROM nginx:alpine
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -438,3 +438,37 @@ a:hover {
 .Loader svg rect {
   fill: var(--color-green);
 }
+
+.ToastContainer {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 200;
+}
+
+.RentalToast {
+  --toast-width: 280px;
+
+  background-color: var(--color-green);
+  color: var(--color-navy);
+  letter-spacing: -.03rem;
+  font-weight: 600;
+  font-size: 14px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  width: var(--toast-width);
+  padding: 12px 16px;
+  border-radius: 8px;
+  box-shadow: var(--shadow-level-1);
+  animation: toastSlideIn 0.3s ease;
+}
+
+@keyframes toastSlideIn {
+  from { transform: translateX(120%); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -34,14 +34,49 @@ class App extends Component {
         lastName: 'Lopez',
         username: 'cindy'
       },
-      fixHeader: false
+      fixHeader: false,
+      toasts: []
     };
 
     this.appRef = React.createRef();
+    this.ws = null;
   }
 
   componentDidMount() {
     this.refreshData();
+    this.connectWebSocket();
+  }
+
+  componentWillUnmount() {
+    if (this.ws) this.ws.close();
+  }
+
+  connectWebSocket = () => {
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const ws = new WebSocket(`${protocol}//${window.location.host}/api/ws`);
+
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data);
+      const movie = this.state.catalog.data.find(m => String(m.id) === data.movie_id);
+      const title = movie?.original_title ?? 'A movie';
+      const id = Date.now();
+
+      this.setState(state => ({
+        toasts: [...state.toasts, { id, message: `"${title}" rented successfully!` }]
+      }));
+
+      setTimeout(() => {
+        this.setState(state => ({
+          toasts: state.toasts.filter(t => t.id !== id)
+        }));
+      }, 4000);
+    };
+
+    ws.onclose = () => {
+      setTimeout(this.connectWebSocket, 3000);
+    };
+
+    this.ws = ws;
   }
 
   handleRent = async (item) => {
@@ -106,10 +141,15 @@ class App extends Component {
   }
 
   render() {
-    const { catalog, rental, session, cost } = this.state;
+    const { catalog, rental, session, cost, toasts } = this.state;
     return (
       <Router>
         <div className="App" ref={this.appRef} onScroll={this.handleScroll}>
+          <div className="ToastContainer">
+            {toasts.map(toast => (
+              <RentalToast key={toast.id} message={toast.message} />
+            ))}
+          </div>
           <div className={`App__header ${this.state.fixHeader ? 'fixed' : ''}`}>
             <Link to="/">
               <div className="App__logo">
@@ -332,6 +372,15 @@ const Symbol = ({ size = '18'}) => {
       <path fill="#00D1CA" d="M6.85 10.5c0-2 1.65-3.65 3.73-3.65 1.19 0 2.24.54 2.92 1.38a1.17 1.17 0 0 0 1.82-1.48A6.1 6.1 0 0 0 4.5 10.5a6.1 6.1 0 0 0 10.82 3.75 1.17 1.17 0 1 0-1.82-1.48 3.75 3.75 0 0 1-2.92 1.38 3.7 3.7 0 0 1-3.73-3.65Z"/>
       <path fill="#00D1CA" d="M15.33 11.67a1.17 1.17 0 1 0 0-2.34 1.17 1.17 0 0 0 0 2.34Z"/>
     </svg>
+  );
+};
+
+const RentalToast = ({ message }) => {
+  return (
+    <div className="RentalToast">
+      <MoviesIcon size="16" />
+      {message}
+    </div>
   );
 };
 

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -84,7 +84,8 @@ module.exports = (_, argv) => {
       proxy: {
         '/rent': 'http://rentals:8080/rent',
         '/rentals': 'http://rentals:8080/rentals',
-        '/catalog': 'http://catalog:8080'
+        '/catalog': 'http://catalog:8080',
+        '/api/ws': { target: 'ws://api:8080', ws: true }
       },
       client: {
         webSocketURL: {

--- a/okteto.yaml
+++ b/okteto.yaml
@@ -3,6 +3,8 @@ icon: https://apps.okteto.com/movies/icon.png
 build:
   frontend:
     context: frontend
+    args:
+      - CACHEBUST=ws-rentals-v2
   catalog:
     context: catalog
   rent:

--- a/worker/cmd/worker/main.go
+++ b/worker/cmd/worker/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
-
-	"fmt"
+	"strings"
 
 	_ "github.com/lib/pq"
 
@@ -70,6 +71,17 @@ func main() {
 				if _, err := db.Exec(insertDynStmt, string(msg.Key), fmt.Sprintf("%f", price)); err != nil {
 					log.Panic(err)
 				}
+				movieID := string(msg.Key)
+				go func() {
+					payload := fmt.Sprintf(`{"movie_id":"%s"}`, movieID)
+					resp, err := http.Post("http://api:8080/internal/notify", "application/json", strings.NewReader(payload))
+					if err != nil {
+						fmt.Println("Error notifying API:", err)
+						return
+					}
+					resp.Body.Close()
+					fmt.Printf("Notified API of rental: %s (status %d)\n", movieID, resp.StatusCode)
+				}()
 			case msg := <-consumerReturns.Messages():
 				catalogID := string(msg.Value)
 				fmt.Printf("Received return message: catalogID %s\n", catalogID)


### PR DESCRIPTION
## Summary

- **API (Go)**: WebSocket hub at `/api/ws` and internal `/internal/notify` endpoint for receiving events from the worker; server-side pings keep connections alive through nginx timeouts
- **Worker (Go)**: After each rental is persisted to PostgreSQL, POSTs the movie ID to the API's notify endpoint
- **Frontend (React)**: Connects WebSocket on mount with auto-reconnect, shows slide-in toast notification in the bottom-right corner when a rental completes
- **Infra**: API ingress routes `/api/ws` with extended timeout annotations; webpack dev proxy forwards `/api/ws` with WebSocket support

Also fixes frontend Docker build caching so source changes are always picked up.

## Test plan

- [ ] Open the app at the deployed URL
- [ ] Click Rent on a movie — toast notification appears in bottom-right: `"<Movie Title>" rented successfully!`
- [ ] Notification auto-dismisses after 4 seconds
- [ ] Connection auto-reconnects if dropped (check browser devtools Network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)