### PR TITLE
Add SD/HD tier selection to rental flow (PROD-506)

### DIFF
--- a/api/cmd/api/main.go
+++ b/api/cmd/api/main.go
@@ -37,6 +37,7 @@ func main() {
 type Rental struct {
 	Movie string
 	Price string
+	Tier  string
 }
 
 type Movie struct {
@@ -46,6 +47,7 @@ type Movie struct {
 	BackdropPath  string  `json:"backdrop_path,omitempty"`
 	Price         float64 `json:"price,omitempty"`
 	Overview      string  `json:"overview,omitempty"`
+	Tier          string  `json:"tier,omitempty"`
 }
 
 type User struct {
@@ -119,7 +121,7 @@ func rentals(w http.ResponseWriter, r *http.Request) {
 
 	for rows.Next() {
 		var r Rental
-		if err := rows.Scan(&r.Movie, &r.Price); err != nil {
+		if err := rows.Scan(&r.Movie, &r.Price, &r.Tier); err != nil {
 			fmt.Println("error scanning row", err)
 			os.Exit(1)
 		}
@@ -157,6 +159,7 @@ func rentals(w http.ResponseWriter, r *http.Request) {
 			if rental.Movie == strconv.Itoa(m.ID) {
 				price, _ := strconv.ParseFloat(rental.Price, 64)
 				m.Price = price
+				m.Tier = rental.Tier
 				result = append(result, m)
 			}
 		}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -285,6 +285,38 @@ a:hover {
   font-size: 26px;
 }
 
+.Item__tier {
+  display: flex;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.Item__tier-option {
+  background: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 12px;
+  padding: 6px 14px;
+  font-size: 14px;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background .125s ease, border-color .125s ease;
+}
+
+.Item__tier-option--active {
+  background: var(--color-red);
+  border-color: var(--color-red);
+}
+
+.Item__badge {
+  background: var(--color-red);
+  border-radius: 12px;
+  padding: 6px 14px;
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
 .Item:hover .Item__overlay {
   opacity: 1;
   pointer-events: all;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -44,7 +44,7 @@ class App extends Component {
     this.refreshData();
   }
 
-  handleRent = async (item) => {
+  handleRent = async (item, tier = 'SD') => {
     await fetch('/rent', {
       method: 'POST',
       headers: {
@@ -52,7 +52,8 @@ class App extends Component {
       },
       body: JSON.stringify({
         catalog_id: item.id,
-        price: item.price
+        price: item.price,
+        tier
       })
     });
     this.refreshData();
@@ -238,7 +239,11 @@ class TitleList extends Component {
   }
 }
 
+const TIERS = ['SD', 'HD'];
+
 const Item = ({ item, onRent, onReturn, backdrop }) => {
+  const [tier, setTier] = React.useState('SD');
+
   return (
     <div className="Item">
       <div className="Item__container" style={{ backgroundImage: `url(./${backdrop})` }}>
@@ -251,12 +256,27 @@ const Item = ({ item, onRent, onReturn, backdrop }) => {
               {!!item?.price &&
                 <div className='Item__price'>${item.price}</div>
               }
+              <div className="Item__tier">
+                {TIERS.map(t => (
+                  <button
+                    key={t}
+                    type="button"
+                    className={`Item__tier-option ${tier === t ? 'Item__tier-option--active' : ''}`}
+                    onClick={() => setTier(t)}
+                  >
+                    {t}
+                  </button>
+                ))}
+              </div>
               <div className="spring" />
-              <div className="Item__button button" onClick={() => onRent(item)}>
+              <div className="Item__button button" onClick={() => onRent(item, tier)}>
                 Rent
               </div>
             </> :
             <>
+              {!!item?.tier &&
+                <div className="Item__badge">{item.tier}</div>
+              }
               <div className="Item__button Item__button--rented button">
                 Watch Now
               </div>

--- a/rent/src/main/java/com/okteto/rent/controller/RentController.java
+++ b/rent/src/main/java/com/okteto/rent/controller/RentController.java
@@ -1,6 +1,9 @@
 package com.okteto.rent.controller;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +25,7 @@ public class RentController {
     private static final String KAFKA_TOPIC_RETURNS = "returns";
 
     private final Logger logger = LoggerFactory.getLogger(RentController.class);
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Autowired
     private KafkaTemplate<String, String> kafkaTemplate;
@@ -35,10 +39,16 @@ public class RentController {
     List<String> rent(@RequestBody Rent rentInput) {
         String catalogID = rentInput.getMovieID();
         Double price = rentInput.getPrice();
+        String tier = rentInput.getTier();
 
-        logger.info("Rent [{},{}] received", catalogID, price);
+        logger.info("Rent [{},{},{}] received", catalogID, price, tier);
 
-        kafkaTemplate.send(KAFKA_TOPIC_RENTALS, catalogID, price.toString())
+        // The "rentals" message value carries both the price and the selected
+        // tier as a small JSON payload. Producer (this service) and consumer
+        // (the Go worker) share this contract.
+        String payload = buildRentalPayload(price, tier);
+
+        kafkaTemplate.send(KAFKA_TOPIC_RENTALS, catalogID, payload)
         .thenAccept(result -> logger.info("Message [{}] delivered with offset {}",
                         catalogID,
                         result.getRecordMetadata().offset()))
@@ -46,9 +56,23 @@ public class RentController {
             logger.warn("Unable to deliver message [{}]. {}", catalogID, ex.getMessage());
             return null;
         });
-        
+
 
         return new LinkedList<>();
+    }
+
+    private String buildRentalPayload(Double price, String tier) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("price", price == null ? "0" : price.toString());
+        node.put("tier", Rent.normalizeTier(tier));
+        try {
+            return objectMapper.writeValueAsString(node);
+        } catch (JsonProcessingException e) {
+            // Should never happen for a plain object node; fall back defensively.
+            logger.warn("Unable to serialize rental payload. {}", e.getMessage());
+            return "{\"price\":\"" + (price == null ? "0" : price.toString())
+                    + "\",\"tier\":\"" + Rent.normalizeTier(tier) + "\"}";
+        }
     }
 
     @PostMapping(path= "/rent/return", consumes = "application/json", produces = "application/json")
@@ -70,9 +94,12 @@ public class RentController {
     }
 
     public static class Rent {
+        static final String DEFAULT_TIER = "SD";
+
         @JsonProperty("catalog_id")
         private String movieID;
         private Double price;
+        private String tier;
 
         public void setMovieID(String movieID) {
             this.movieID = movieID;
@@ -89,6 +116,23 @@ public class RentController {
 
         public Double getPrice() {
             return price;
+        }
+
+        public void setTier(String tier) {
+            this.tier = tier;
+        }
+
+        public String getTier() {
+            return tier;
+        }
+
+        // SD is the default; anything other than SD/HD falls back to SD.
+        static String normalizeTier(String tier) {
+            if (tier == null) {
+                return DEFAULT_TIER;
+            }
+            String normalized = tier.trim().toUpperCase();
+            return normalized.equals("HD") ? "HD" : DEFAULT_TIER;
         }
     }
 

--- a/worker/cmd/worker/main.go
+++ b/worker/cmd/worker/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"log"
 	"os"
 	"os/signal"
@@ -22,6 +23,28 @@ var (
 	messageCountStart = kingpin.Flag("messageCountStart", "Message counter start from:").Int()
 )
 
+// rentalMessage is the shared contract for the "rentals" Kafka topic value,
+// produced by the rent (Java) service. It carries the price and the selected
+// video quality tier.
+type rentalMessage struct {
+	Price string `json:"price"`
+	Tier  string `json:"tier"`
+}
+
+// parseRentalMessage decodes the JSON payload. For robustness against any
+// legacy plain-price messages still on the topic, it falls back to treating
+// the whole value as the price with the default SD tier.
+func parseRentalMessage(value []byte) rentalMessage {
+	var msg rentalMessage
+	if err := json.Unmarshal(value, &msg); err != nil || msg.Price == "" {
+		return rentalMessage{Price: string(value), Tier: "SD"}
+	}
+	if msg.Tier == "" {
+		msg.Tier = "SD"
+	}
+	return msg
+}
+
 func main() {
 	db := database.Open()
 	defer db.Close()
@@ -33,7 +56,7 @@ func main() {
 		log.Panic(err)
 	}
 
-	createTableStmt := `CREATE TABLE IF NOT EXISTS rentals (id VARCHAR(255) NOT NULL UNIQUE, price VARCHAR(255) NOT NULL)`
+	createTableStmt := `CREATE TABLE IF NOT EXISTS rentals (id VARCHAR(255) NOT NULL UNIQUE, price VARCHAR(255) NOT NULL, tier VARCHAR(255) NOT NULL DEFAULT 'SD')`
 	if _, err := db.Exec(createTableStmt); err != nil {
 		log.Panic(err)
 	}
@@ -64,10 +87,11 @@ func main() {
 				fmt.Println(err)
 			case msg := <-consumerRentals.Messages():
 				*messageCountStart++
-				fmt.Printf("Received message: movies %s price %s\n", string(msg.Key), string(msg.Value))
-				price, _ := strconv.ParseFloat(string(msg.Value), 64)
-				insertDynStmt := `insert into "rentals"("id", "price") values($1, $2) on conflict(id) do update set price = $2`
-				if _, err := db.Exec(insertDynStmt, string(msg.Key), fmt.Sprintf("%f", price)); err != nil {
+				fmt.Printf("Received message: movies %s value %s\n", string(msg.Key), string(msg.Value))
+				rental := parseRentalMessage(msg.Value)
+				price, _ := strconv.ParseFloat(rental.Price, 64)
+				insertDynStmt := `insert into "rentals"("id", "price", "tier") values($1, $2, $3) on conflict(id) do update set price = $2, tier = $3`
+				if _, err := db.Exec(insertDynStmt, string(msg.Key), fmt.Sprintf("%f", price), rental.Tier); err != nil {
 					log.Panic(err)
 				}
 			case msg := <-consumerReturns.Messages():


### PR DESCRIPTION
## What & why

Implements [PROD-506](https://okteto.atlassian.net/browse/PROD-506): let users choose a video quality tier (**SD** or **HD**) when renting a movie and surface it in **My Rentals**. The selected tier travels the full cross-service pipeline alongside the existing price:

`frontend → POST /rent → rent (Java) → Kafka "rentals" → worker (Go) → Postgres → api (Go) GET /rentals → frontend`

## The cross-service contract change

The `rentals` Kafka message value previously carried only the price as a bare string (`"3.99"`). It now carries a small JSON payload shared by the Java producer and Go consumer:

```json
{"price": "3.99", "tier": "HD"}
```

## Changes by service

- **frontend** (`App.jsx`, `App.css`): SD/HD selector on each store item (SD default), `tier` added to the `POST /rent` body, and a tier badge shown on rented items.
- **rent** (Java): `Rent` DTO accepts `tier`; emits the JSON `{price, tier}` payload. Unknown/missing tiers normalize to `SD`.
- **worker** (Go): parses the JSON payload, adds a `tier` column (`DEFAULT 'SD'`) to the `rentals` table, and persists it. Falls back to `SD` for any legacy plain-price message.
- **api** (Go): `Rental`/`Movie` structs carry `Tier`; scanned and returned from `GET /rentals`.

## Verification

Builds: Go `build`/`vet` clean (api, worker), Java `mvn compile` succeeds, frontend webpack build succeeds.

Deployed to Okteto (`demo.okteto.dev`) and exercised end-to-end:

- Rent HD -> `/rentals` returns `tier: "HD"`; rent SD -> `tier: "SD"`; both correct simultaneously
- Renting with no `tier` field defaults to `SD`
- Prices unchanged
- Tier selector + badge present in the served frontend bundle

**Note on e2e:** the `catalog has entries` test currently fails (expects 6, environment has 20) due to an **unrelated** in-progress change to `catalog/data/catalog.json` that is *not* part of this PR. The other e2e tests pass, and this PR does not touch the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PROD-506]: https://okteto.atlassian.net/browse/PROD-506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ