### PR TITLE
preview: support GitHub stacked pull requests

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,7 +1,24 @@
-on: 
+on:
   pull_request:
     branches:
       - main
+
+# Merging a lower layer of a stack sends more than one synchronize event per
+# layer above it, so without this two deploys can race into one preview.
+concurrency:
+  group: preview-${{ github.event.number }}
+  cancel-in-progress: true
+
+# statuses: write marks a commit as previewed, and pull-requests: write posts the
+# preview URL on a backfilled layer's own PR. Neither is granted by the default
+# read-only GITHUB_TOKEN.
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
+env:
+  PREVIEW_STATUS_CONTEXT: okteto/preview
 
 jobs:
   preview:
@@ -21,6 +38,16 @@ jobs:
         name: pr-${{ github.event.number }}-cindylopez
         scope: global
 
+    - name: Mark this commit as previewed
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh api -X POST "repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha }}" \
+          -f state=success \
+          -f context="$PREVIEW_STATUS_CONTEXT" \
+          -f description="Preview environment deployed" \
+          -f target_url="${{ secrets.OKTETO_URL }}/previews/pr-${{ github.event.number }}-cindylopez"
+
     - name: Checkout code
       uses: actions/checkout@v4
 
@@ -29,7 +56,7 @@ jobs:
       with:
         tests: e2e
         namespace: pr-${{ github.event.number }}-cindylopez
-        
+
     - name: Save playwright report
       uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
@@ -37,7 +64,7 @@ jobs:
         name: playwright-report
         path: tests/playwright-report/
         retention-days: 30
-        
+
     - name: Save test results
       uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
@@ -46,3 +73,102 @@ jobs:
           path: tests/test-results/
           retention-days: 30
           include-hidden-files: true
+
+  # When a stack is first submitted, GitHub only sends pull_request events for
+  # the bottom and the top layer. Every layer in between opens with no run at
+  # all, so it gets no preview and no failing check to say so. The top layer
+  # always fires, so it is the one place we can reliably notice and backfill.
+  find-skipped-layers:
+    if: ${{ github.event.pull_request.stack && github.event.pull_request.stack.position == github.event.pull_request.stack.size }}
+    runs-on: ubuntu-latest
+    outputs:
+      layers: ${{ steps.find.outputs.layers }}
+    steps:
+    - name: Find stack layers that never got a preview
+      id: find
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO: ${{ github.repository }}
+        STACK: ${{ github.event.pull_request.stack.number }}
+      run: |
+        candidates=$(gh api "repos/$REPO/pulls?state=open&per_page=100" \
+          --jq "[ .[]
+                  | select(.stack.number == $STACK)
+                  | select(.stack.position > 1 and .stack.position < .stack.size)
+                  | {number: .number, branch: .head.ref, sha: .head.sha} ]")
+        echo "candidates: $candidates"
+
+        # Skip layers that already carry the previewed marker, so pushing to the
+        # top of a stack does not redeploy every layer underneath it.
+        missing="[]"
+        while read -r row; do
+          [ -z "$row" ] && continue
+          sha=$(printf '%s' "$row" | jq -r '.sha')
+          count=$(gh api "repos/$REPO/commits/$sha/statuses" \
+            --jq "[ .[] | select(.context == \"$PREVIEW_STATUS_CONTEXT\") ] | length")
+          if [ "$count" -eq 0 ]; then
+            missing=$(printf '%s' "$missing" | jq -c --argjson r "$row" '. + [$r]')
+            echo "  needs preview: $row"
+          else
+            echo "  already previewed, skipping: $row"
+          fi
+        done <<EOF
+        $(printf '%s' "$candidates" | jq -c '.[]')
+        EOF
+
+        echo "layers=$missing" >> "$GITHUB_OUTPUT"
+
+  preview-skipped-layer:
+    needs: find-skipped-layers
+    if: ${{ needs.find-skipped-layers.outputs.layers != '' && needs.find-skipped-layers.outputs.layers != '[]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        layer: ${{ fromJSON(needs.find-skipped-layers.outputs.layers) }}
+    steps:
+    - name: Context
+      uses: okteto/context@latest
+      with:
+        token: ${{ secrets.OKTETO_TOKEN }}
+        url: ${{ secrets.OKTETO_URL }}
+
+    # GITHUB_TOKEN is deliberately not passed to deploy-preview here. The action
+    # reads the PR number from the event payload, so it would comment the layer's
+    # preview URL on this PR instead of the layer's own PR.
+    - name: Deploy preview environment for skipped layer
+      uses: okteto/deploy-preview@latest
+      with:
+        name: pr-${{ matrix.layer.number }}-cindylopez
+        branch: ${{ matrix.layer.branch }}
+        scope: global
+
+    - name: Mark the layer's commit as previewed
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh api -X POST "repos/${{ github.repository }}/statuses/${{ matrix.layer.sha }}" \
+          -f state=success \
+          -f context="$PREVIEW_STATUS_CONTEXT" \
+          -f description="Preview environment deployed by stack backfill" \
+          -f target_url="${{ secrets.OKTETO_URL }}/previews/pr-${{ matrix.layer.number }}-cindylopez"
+
+    - name: Checkout the layer's code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ matrix.layer.branch }}
+
+    - name: Run end to end tests
+      uses: okteto/test@latest
+      with:
+        tests: e2e
+        namespace: pr-${{ matrix.layer.number }}-cindylopez
+
+    - name: Post the preview URL on the layer's own PR
+      if: ${{ !cancelled() }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh pr comment "${{ matrix.layer.number }}" \
+          --repo "${{ github.repository }}" \
+          --body "Your preview environment [pr-${{ matrix.layer.number }}-cindylopez](${{ secrets.OKTETO_URL }}/previews/pr-${{ matrix.layer.number }}-cindylopez) has been deployed by the stack backfill in #${{ github.event.number }}, because GitHub does not run checks on intermediate layers of a stack."


### PR DESCRIPTION
GitHub's native stacked pull requests (public preview since 2026-07-30) mostly work with our preview environments, but validation on this repo turned up three problems. This fixes all three.

## What was broken

1. **Intermediate layers got no preview at all.** When a stack is first submitted, GitHub only sends `pull_request` events for the bottom and the top layer. Every layer in between opens with zero workflow runs, so `gh pr checks` reports "no checks reported" and the reviewer of that layer has no environment and no signal that one is missing. Reproduced 4/4 across two repos and stack depths of 3 and 4.
2. **A rebase cascade can race two deploys into one namespace.** Merging a lower layer sends *two* `synchronize` events per layer above it, and this workflow had no `concurrency` group.
3. **A push to the top redeployed every layer beneath it**, once backfill was added naively. Confirmed live before adding the idempotency marker.

## What changed

- `concurrency: preview-<pr>` with `cancel-in-progress`, so only one deploy per PR is ever in flight.
- `find-skipped-layers` + `preview-skipped-layer`: the top layer of a stack (which always fires) enumerates the stack via the REST API, finds the layers GitHub skipped, and deploys a preview plus e2e tests for each. The preview URL is commented on the layer's *own* PR, not on the top one.
- An `okteto/preview` commit status marks a SHA as previewed. The backfill skips layers that already carry it, so it runs once per layer, and each layer now shows a real green check instead of an empty check list.
- Explicit `permissions:` block. `statuses: write` and `pull-requests: write` are not granted by the default read-only `GITHUB_TOKEN`.

## Validation

Tested end to end on a 4-layer stack in this repo (PRs #168-#171, now closed and cleaned up):

| Layer | Preview | Contents served | e2e |
|---|---|---|---|
| l1 (bottom, own run) | `pr-168-cindylopez` | `L1` | pass |
| l2 (middle, backfilled) | `pr-169-cindylopez` | `L1,L2` | pass |
| l3 (middle, backfilled) | `pr-170-cindylopez` | `L1,L2,L3` | pass |
| l4 (top, own run) | `pr-171-cindylopez` | `L1,L2,L3,L4` | pass |

Each layer's preview served exactly its own cumulative state, and closing the PRs destroyed all four previews. The idempotency path (second event on the top layer skips already-previewed layers) was verified separately with the same logic in a scratch repo.

## Tradeoff worth a look

This gives every layer its own environment, which for this repo means N x 6 services per stack. If that is too expensive, the alternative is one environment for the whole stack: gate the deploy on `github.event.pull_request.stack.position == github.event.pull_request.stack.size` and drop the backfill jobs. That also sidesteps problem 1 entirely, at the cost of middle-layer reviewers having no environment by design.

Full write-up of the validation: https://claude.ai/code/artifact/4c2d05e8-d6ee-46df-a7de-051e8cbdcdc1

🤖 Generated with [Claude Code](https://claude.com/claude-code)